### PR TITLE
Pin Python version for entity linking workflow

### DIFF
--- a/.github/workflows/entity_linking.yml
+++ b/.github/workflows/entity_linking.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.12'
           cache: 'pip'
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- fix GitHub Action runtime by pinning Python to 3.12

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e0c1238bc83209205e3abda3a1fd2