### PR TITLE
Add sleeper_id handling to PlayerDataTransformer

### DIFF
--- a/src/core/data/transform.py
+++ b/src/core/data/transform.py
@@ -259,7 +259,7 @@ class PlayerDataTransformer(BaseDataTransformer):
                     sleeper_id = str(int(sleeper_value)) if float(sleeper_value).is_integer() else str(sleeper_value)
                 else:
                     sleeper_id = str(sleeper_value).strip()
-            except Exception:
+            except (ValueError, TypeError):
                 sleeper_id = str(sleeper_value)
 
         # Handle draft information

--- a/src/core/data/transform.py
+++ b/src/core/data/transform.py
@@ -249,6 +249,19 @@ class PlayerDataTransformer(BaseDataTransformer):
             except:
                 birth_date = None
         
+        # Handle Sleeper ID
+        sleeper_id = None
+        sleeper_value = row.get('sleeper_id') if hasattr(row, 'get') else None
+        if pd.notna(sleeper_value):
+            try:
+                # Keep Sleeper IDs canonical by stripping whitespace and removing decimal suffixes
+                if isinstance(sleeper_value, float):
+                    sleeper_id = str(int(sleeper_value)) if float(sleeper_value).is_integer() else str(sleeper_value)
+                else:
+                    sleeper_id = str(sleeper_value).strip()
+            except Exception:
+                sleeper_id = str(sleeper_value)
+
         # Handle draft information
         draft_year = None
         draft_round = None
@@ -311,7 +324,8 @@ class PlayerDataTransformer(BaseDataTransformer):
             "draft_year": draft_year,
             "draft_round": draft_round,
             "draft_pick": draft_pick,
-            "draft_team": draft_team
+            "draft_team": draft_team,
+            "sleeper_id": sleeper_id
         }
         
         # Skip if critical data is missing
@@ -742,4 +756,3 @@ class PlayerWeeklyStatsDataTransformer(BaseDataTransformer):
         except Exception as e:
             self.logger.error(f"Error generating game_id: {e}")
             return None
-

--- a/tests/test_player_data_transformer.py
+++ b/tests/test_player_data_transformer.py
@@ -1,0 +1,49 @@
+"""Tests for PlayerDataTransformer specific transformations."""
+
+import unittest
+import pandas as pd
+
+from src.core.data.transform import PlayerDataTransformer
+
+
+class TestPlayerDataTransformer(unittest.TestCase):
+    """Test cases for PlayerDataTransformer transformations."""
+
+    def test_transform_includes_sleeper_id(self):
+        """Sleeper ID from the source data is preserved in the transformed record."""
+        df = pd.DataFrame([
+            {
+                'player_id': '00-1234567',
+                'player_name': 'Test Player',
+                'first_name': 'Test',
+                'last_name': 'Player',
+                'birth_date': '1990-01-01',
+                'height': 74,
+                'weight': 210,
+                'college': 'Test University',
+                'position': 'QB',
+                'rookie_year': 2015,
+                'season': 2024,
+                'football_name': 'T. Player',
+                'jersey_number': 12,
+                'status': 'Active',
+                'team': 'KC',
+                'years_exp': 10,
+                'headshot_url': None,
+                'sleeper_id': 123456.0,
+                'draft_number': 10,
+                'draft_club': 'KC'
+            }
+        ])
+
+        transformer = PlayerDataTransformer()
+        transformed_records = transformer.transform(df)
+
+        self.assertEqual(len(transformed_records), 1)
+        record = transformed_records[0]
+        self.assertIn('sleeper_id', record)
+        self.assertEqual(record['sleeper_id'], '123456')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Implement handling for `sleeper_id` in the `PlayerDataTransformer`, ensuring it is correctly transformed and included in the output. Add corresponding unit tests to verify the functionality.